### PR TITLE
Fix performance issues on the pinephone

### DIFF
--- a/qml/pages/LoginPage.qml
+++ b/qml/pages/LoginPage.qml
@@ -71,7 +71,7 @@ UUITK.Page {
         UUITK.ActivityIndicator {
             Layout.topMargin: units.gu(2)
             Layout.fillWidth: true
-            running: true
+            running: busy
             visible: busy
         }
     }

--- a/qml/pages/NewsPage.qml
+++ b/qml/pages/NewsPage.qml
@@ -139,7 +139,7 @@ UUITK.Page {
         anchors.fill: parent
         UUITK.ActivityIndicator {
             anchors.centerIn: parent
-            running: true
+            running: searching
             visible: searching
         }
     }

--- a/qml/pages/ThreadView.qml
+++ b/qml/pages/ThreadView.qml
@@ -54,7 +54,7 @@ UUITK.Page {
         anchors.fill: parent
         UUITK.ActivityIndicator {
             anchors.centerIn: parent
-            running: true
+            running: loading
             visible: loading
         }
     }


### PR DESCRIPTION
There is an issue on the pinephone where performance of an app is really bad (especially when scrolling, it gets laggy) when an activity indicator is left running in the 'background.' I don't know all the technical details, but teleports had this issue a while back. The fix in this case seems to be just using the same boolean for `running` as you use for `visible`
I've tested this on my pinephone and it works, I don't have a different device to test on though. Please let me know if you want me to make any changes.

Great app, by the way! I really like it!